### PR TITLE
Fix CLI top-k validation

### DIFF
--- a/src/entrypoint/cli.ts
+++ b/src/entrypoint/cli.ts
@@ -33,12 +33,15 @@ program
   .option('-k, --top-k <number>', 'Number of top results to return', '5')
   .action(async (query, options) => {
     try {
-      const topK = parseInt(options.topK)
+      const topK = parseInt(options.topK, 10)
+      if (!Number.isInteger(topK) || topK <= 0) {
+        throw new Error('The value for --top-k must be a positive integer')
+      }
       console.log('🚀 Starting query...')
       const results = await queryDb(query, topK)
       
       console.log('\n📋 Results:')
-      console.log('=' .repeat(50))
+      console.log('='.repeat(50))
       
       results.forEach((result, index) => {
         console.log(`\n📄 Result ${index + 1} (Score: ${result.score?.toFixed(4) || 'N/A'})`)


### PR DESCRIPTION
## Summary
- add validation for `--top-k` option in CLI
- minor formatting fix for query output

## Testing
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_683f7b6dbab48330a8118d898ad9f573