### PR TITLE
Fix MCP json snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ docker build -t custom-info-local-mcp .
   "mcpServers": {
     "custom-info": {
       "command": "docker",
-      "args": ["run", "--rm", "-i","custom-info-local-mcp"],
+      "args": ["run", "--rm", "-i", "custom-info-local-mcp"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove trailing comma from the JSON snippet in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f7c53bb608330bc98b593f6ce7976